### PR TITLE
fixed typo in admin products page

### DIFF
--- a/js/admin/adminContent.js
+++ b/js/admin/adminContent.js
@@ -284,7 +284,7 @@ const showGlobalProductRequests = async () => {
             //No products are active
             let noProducts = createElement("div", "msg", "message");
 
-            noProducts.innerText = "Inga aktiva globala produkter";
+            noProducts.innerText = "Inga inaktiva globala produkter";
             appendElementToApp(noProducts, mainContent);
         }
     }


### PR DESCRIPTION
"no *IN*active products" under the inactive list instead of "no active products"